### PR TITLE
Added support for Dokan 740

### DIFF
--- a/src/net/srcdemo/userfs/UserFSUtils.java
+++ b/src/net/srcdemo/userfs/UserFSUtils.java
@@ -101,7 +101,7 @@ public final class UserFSUtils {
 		addPathToLibrary(os.getLibraryPath());
 		if (os.isWindows()) {
 			try {
-				if (Dokan.getVersion() == 600) {
+				if (Dokan.getVersion() == 600 || Dokan.getVersion() == 740) {
 					if (SrcLogger.getLogMisc()) {
 						SrcLogger.log("Starting with version = " + Dokan.getVersion() + " / Driver = "
 							+ Dokan.getDriverVersion() + ".");


### PR DESCRIPTION
This allows SrcDemo2 to work with newer windows versions. The API has not changed in [version 740](https://github.com/dokan-dev/dokany/releases/tag/v0.7.4), so it works fine (I have tested this).
